### PR TITLE
bugfix: remove unusable quest in enum

### DIFF
--- a/src/main/java/net/botwithus/debug/DebugScript.java
+++ b/src/main/java/net/botwithus/debug/DebugScript.java
@@ -159,7 +159,6 @@ public class DebugScript extends LoopingScript {
         GHOSTS_AHOY(82),
         VESSEL_HARINGER(495),
         SPIRIT_WAR(496),
-        TOME_OF_WARLOCK(497),
         DIAMOND_ROUGH(356),
         JACK_OF_SPADES(390),
         DAUGHTER_OF_CHAOS(483),


### PR DESCRIPTION
`TOMES_OF_WARLOCK` is in there and works. `TOME_OF_WARLOCK` doesn't.